### PR TITLE
updates docker script to accept different names (#3)

### DIFF
--- a/run_docker_container.sh
+++ b/run_docker_container.sh
@@ -1,4 +1,8 @@
-containername="ghrb_framework"
+containername=$1
+
+if [ -z "$containername" ]; then
+    containername="ghrb_framework"
+fi
 
 docker ps -aq --filter "name=$containername" | grep -q . && docker stop $containername && docker rm $containername
 docker run -dt --name $containername -v $(pwd):/root/framework ghrb_framework:latest


### PR DESCRIPTION
The `run_docker_container.sh` script will take in a command line argument that allows one to run it in parallel with different container names.